### PR TITLE
Feature: add Nix flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,69 @@ The AUR package automatically tracks the latest modern version:
 yay -S pixie-sddm-git
 ```
 
-### Method C: NixOS (Declarative)
-Add the following to your `configuration.nix`. (Change `rev = "main"` to `rev = "qt5"` for legacy systems).
+### Method C: NixOS (Flake)
+The most modern and flexible way to install.
 
-> **Note for Qt6:** If you are using the `main` (Qt6) branch, you **must** use `pkgs.kdePackages.sddm` to ensure the Qt6 platform plugins load correctly. Without this, your mouse cursor may not appear.
+1. In your **`flake.nix`**, add the input and pass it to your modules:
+```nix
+{
+  inputs.pixie-sddm.url = "github:xCaptaiN09/pixie-sddm";
+
+  outputs = { self, nixpkgs, pixie-sddm, ... }@inputs: {
+    nixosConfigurations.YOUR_HOSTNAME = nixpkgs.lib.nixosSystem {
+      specialArgs = { inherit inputs; }; # Passes inputs to all modules
+      modules = [ ./configuration.nix ];
+    };
+  };
+}
+```
+
+2. In your **`configuration.nix`**, configure SDDM and apply the theme:
+```nix
+{ pkgs, inputs, ... }: {
+  services.displayManager.sddm = {
+    enable = true;
+    theme = "pixie";
+    wayland.enable = true; # Optional: for Wayland sessions
+
+    # Crucial for Qt6: Use the KDE/Qt6 build of SDDM to fix missing
+    # cursors and module errors.
+    package = pkgs.kdePackages.sddm;
+
+    # Required dependencies for Qt6 themes
+    extraPackages = [
+      pkgs.kdePackages.qtsvg
+      pkgs.kdePackages.qtdeclarative
+      pkgs.kdePackages.qt5compat
+    ];
+  };
+
+  environment.systemPackages = [
+    # Install and customize the theme. All fields are optional and will
+    # fall back to theme defaults if not set.
+    (inputs.pixie-sddm.packages.${pkgs.stdenv.hostPlatform.system}.pixie-sddm.override {
+      background = ./my-background.jpg; # Nix path or absolute path
+      avatar = ./my-avatar.jpg;         # Nix path or absolute path
+      primaryColor = "#B3C8FF";         # Hex color code
+      accentColor = "#3F5F91";          # Hex color code
+      autoColor = true;                 # true/false
+      backgroundColor = "#1A1C1E";      # Hex color code
+      textColor = "#E2E2E6";            # Hex color code
+      fontFamily = "JetBrains Mono";    # Font family name
+      fontSize = 13;                    # Font size in px
+    })
+  ];
+}
+```
+
+### Method D: NixOS (Legacy / Non-Flake)
+Add the following to your `configuration.nix`. (Change `rev = "main"` to
+`rev = "qt5"` for legacy systems).
+
+> [!NOTE]
+> For Qt6: If you are using the `main` (Qt6) branch, you **must** use
+> `pkgs.kdePackages.sddm` to ensure the Qt6 platform plugins load
+> correctly. Without this, your mouse cursor may not appear.
 
 ```nix
 { pkgs, ... }: {
@@ -98,8 +157,8 @@ Add the following to your `configuration.nix`. (Change `rev = "main"` to `rev = 
     enable = true;
     theme = "pixie";
     # Crucial for Qt6: Use the KDE/Qt6 build of SDDM to fix missing cursors and module errors
-    package = pkgs.kdePackages.sddm; 
-    
+    package = pkgs.kdePackages.sddm;
+
     # Fix for NixOS explicitly requiring a cursor theme
     settings = {
       Theme = {
@@ -130,7 +189,7 @@ Add the following to your `configuration.nix`. (Change `rev = "main"` to `rev = 
 }
 ```
 
-### Method D: Manual
+### Method E: Manual
 1. Copy the folder to SDDM themes directory:
    `sudo cp -r pixie-sddm /usr/share/sddm/themes/pixie`
 2. Set the theme in `/etc/sddm.conf`:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,110 @@
+{
+  description = "Pixie SDDM theme - A clean, modern, and minimal SDDM theme";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        lib = pkgs.lib;
+
+        makeTheme =
+          {
+            background ? null,
+            avatar ? null,
+            primaryColor ? null,
+            accentColor ? null,
+            autoColor ? null,
+            backgroundColor ? null,
+            textColor ? null,
+            fontFamily ? null,
+            fontSize ? null,
+            ...
+          }@args:
+          let
+            # Helper to convert Nix types to SDDM-compatible strings
+            toIniValue = v: if builtins.isBool v then (if v then "true" else "false") else toString v;
+
+            # Explicitly capture known arguments to satisfy the linter.
+            knownArgs = {
+              inherit
+                background
+                primaryColor
+                accentColor
+                autoColor
+                backgroundColor
+                textColor
+                fontFamily
+                fontSize
+                ;
+            };
+
+            # Combine known arguments with any extra ones passed via @args,
+            # then filter out nulls and special fields like 'avatar'.
+            cfgArgs = lib.filterAttrs (n: v: v != null) (
+              knownArgs // (removeAttrs args (builtins.attrNames knownArgs ++ [ "avatar" ]))
+            );
+          in
+          pkgs.stdenvNoCC.mkDerivation {
+            pname = "pixie-sddm";
+            version = "3.0${lib.optionalString (self ? shortRev) "-${self.shortRev}"}";
+
+            src = lib.fileset.toSource {
+              root = ./.;
+              fileset = lib.fileset.unions [
+                ./Main.qml
+                ./metadata.desktop
+                ./theme.conf
+                ./assets
+                ./components
+                ./LICENSE
+              ];
+            };
+
+            postPatch = ''
+              # Helper to update or append keys in theme.conf
+              update_ini() {
+                local key="$1"
+                local value="$2"
+                [ -z "$value" ] && return
+
+                if grep -q "^$key=" theme.conf; then
+                  sed -i "s|^$key=.*|$key=$value|" theme.conf
+                else
+                  echo "$key=$value" >> theme.conf
+                fi
+              }
+
+              # Dynamically generate update_ini calls for all configuration arguments
+              ${lib.concatStringsSep "\n" (
+                lib.mapAttrsToList (k: v: ''update_ini "${k}" "${toIniValue v}"'') cfgArgs
+              )}
+            '';
+
+            installPhase = ''
+              mkdir -p $out/share/sddm/themes/pixie
+              cp -r * $out/share/sddm/themes/pixie/
+
+              # Replace avatar asset if a custom path is provided
+              ${lib.optionalString (avatar != null) ''
+                cp -f ${avatar} $out/share/sddm/themes/pixie/assets/avatar.jpg
+              ''}
+            '';
+          };
+      in
+      {
+        packages.pixie-sddm = lib.makeOverridable makeTheme { };
+        packages.default = self.packages.${system}.pixie-sddm;
+      }
+    );
+}


### PR DESCRIPTION
Hello xCaptaiN09,

This Pull Request introduces a Nix flake for the Pixie SDDM theme. Thank you for creating such an excellent and clean theme!

The implementation of this Nix flake significantly simplifies the installation and customization process for NixOS users, making it fully declarative.

Key benefits of this implementation include:
- **Convenient Field Overrides**: Users can now easily customize parameters like background, colors, and fonts using Nix arguments, without directly editing theme files.
- **Flexible Configuration**: The build automatically reads fields from your `theme.conf`. This allows users to override only the necessary parameters while retaining all other default values.
- **Resilience to Changes**: If you add new fields to `theme.conf` in future versions, it will not break the flake build. These new fields will be used with their default values and can be easily added for overriding in the flake when needed.
- **Declarative Installation**: Fully integrates with NixOS, providing a reproducible and easily manageable installation.

I have also updated the README.md to include detailed instructions on how to install the theme using the Nix flake, including examples with field overrides.

I have tested the build on my NixOS [configuration](https://github.com/MOIS3Y/nixos-configurations/commit/298e5ff914561586254cc0f191eb8b85c778c4ad), overriding all available fields, and everything is working correctly.

```console
nix-shell -p nix-info --run "nix-info -m"
 - system: `"x86_64-linux"`
 - host os: `Linux 6.18.24, NixOS, 26.05 (Yarara), 26.05.20260422.0726a0e`
 - multi-user?: `yes`
 - sandbox: `yes`
 - version: `nix-env (Nix) 2.34.6`
 - channels(root): `"nixos"`
 - nixpkgs: `/nix/store/75bkaivfbwq3x8cs7155hag7hs1chjcx-source`
```

<details>
<summary>Screenshots of my build</summary>

<img width="1919" height="1078" alt="2026-04-28-22-13-01" src="https://github.com/user-attachments/assets/60536766-a85e-4961-af2a-b24a8e621db0" />
<img width="1915" height="1077" alt="2026-04-28-22-13-57" src="https://github.com/user-attachments/assets/6bd83b0e-ae20-4eb6-ae64-5761b2d122e8" />


</details>

I hope this enhancement will be beneficial for the NixOS community!
