### PR TITLE
fix: honor fontFamily, remove unused primaryColor and fontSize

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -233,6 +233,9 @@ Rectangle {
     FontLoader { id: fontMedium; source: "assets/fonts/FlexRounded-M.ttf" }
     FontLoader { id: fontBold; source: "assets/fonts/FlexRounded-B.ttf" }
 
+    property string activeFontRegular: (config.fontFamily && config.fontFamily.length > 0) ? config.fontFamily : fontRegular.name
+    property string activeFontBold:    (config.fontFamily && config.fontFamily.length > 0) ? config.fontFamily : fontBold.name
+
     Image {
         id: backgroundImage
         source: config.background
@@ -296,7 +299,7 @@ Rectangle {
         text: Qt.formatDateTime(new Date(), "dddd, MMMM d")
         color: container.extractedAccent
         font.pixelSize: 22
-        font.family: fontRegular.name
+        font.family: activeFontRegular
         anchors {
             top: parent.top
             left: parent.left
@@ -319,7 +322,7 @@ Rectangle {
             anchors.centerIn: parent
             backgroundSource: config.background
             baseAccent: container.extractedAccent
-            fontFamily: fontRegular.name
+            fontFamily: container.activeFontRegular
             opacity: container.uiReady ? 1 : 0
             Behavior on opacity { NumberAnimation { duration: 300 } }
         }
@@ -416,7 +419,7 @@ Rectangle {
                             }
                             color: container.extractedAccent
                             font.pixelSize: 48
-                            font.family: fontBold.name
+                            font.family: activeFontBold
                             font.weight: Font.Bold
                         }
                     }
@@ -505,7 +508,7 @@ Rectangle {
                         color: "white"
                         font.pixelSize: 24
                         font.weight: Font.Bold
-                        font.family: fontRegular.name
+                        font.family: activeFontRegular
                     }
 
                     MouseArea {
@@ -601,7 +604,7 @@ Rectangle {
                     text: "Num Lock is on"
                     color: container.extractedAccent
                     font.pixelSize: 14
-                    font.family: fontRegular.name
+                    font.family: activeFontRegular
                     font.weight: Font.Medium
                     Layout.alignment: Qt.AlignHCenter
                     visible: {
@@ -720,7 +723,7 @@ Rectangle {
                             }
                             color: isCurrent ? baseColor : "white"
                             font.pixelSize: 12
-                            font.family: fontBold.name
+                            font.family: activeFontBold
                             font.weight: Font.Bold
                         }
                     }
@@ -737,7 +740,7 @@ Rectangle {
                         }
                         color: isCurrent ? "white" : (hovered ? "#DDDDDD" : "#AAAAAA")
                         font.pixelSize: 15
-                        font.family: fontRegular.name
+                        font.family: activeFontRegular
                         horizontalAlignment: Text.AlignHCenter
                         verticalAlignment: Text.AlignVCenter
                         rightPadding: 60
@@ -824,7 +827,7 @@ Rectangle {
                         }
                         color: isCurrent ? "white" : "#AAAAAA"
                         font.pixelSize: 14
-                        font.family: fontRegular.name
+                        font.family: activeFontRegular
                         horizontalAlignment: Text.AlignHCenter
                         verticalAlignment: Text.AlignVCenter
                         rightPadding: 60

--- a/README.md
+++ b/README.md
@@ -130,13 +130,11 @@ The most modern and flexible way to install.
     (inputs.pixie-sddm.packages.${pkgs.stdenv.hostPlatform.system}.pixie-sddm.override {
       background = ./my-background.jpg; # Nix path or absolute path
       avatar = ./my-avatar.jpg;         # Nix path or absolute path
-      primaryColor = "#B3C8FF";         # Hex color code
       accentColor = "#3F5F91";          # Hex color code
       autoColor = true;                 # true/false
       backgroundColor = "#1A1C1E";      # Hex color code
       textColor = "#E2E2E6";            # Hex color code
-      fontFamily = "JetBrains Mono";    # Font family name
-      fontSize = 13;                    # Font size in px
+      fontFamily = "JetBrains Mono";    # Font family name (must be installed system-wide)
     })
   ];
 }

--- a/flake.nix
+++ b/flake.nix
@@ -22,13 +22,11 @@
           {
             background ? null,
             avatar ? null,
-            primaryColor ? null,
             accentColor ? null,
             autoColor ? null,
             backgroundColor ? null,
             textColor ? null,
             fontFamily ? null,
-            fontSize ? null,
             ...
           }@args:
           let
@@ -39,13 +37,11 @@
             knownArgs = {
               inherit
                 background
-                primaryColor
                 accentColor
                 autoColor
                 backgroundColor
                 textColor
                 fontFamily
-                fontSize
                 ;
             };
 

--- a/theme.conf
+++ b/theme.conf
@@ -2,14 +2,12 @@
 # Path to the wallpaper. If it's in the assets folder, use "assets/background.jpg"
 background=assets/background.jpg
 
-# Material You-like colors (we can refine these)
-primaryColor=#E3E3DC
+# Colors
 accentColor=#A9C78F
 autoColor=true
 use24HourClock=false
 backgroundColor=#1A1C18
 textColor=#E3E3DC
 
-# Font settings
-fontFamily=FlexRounded
-fontSize=12
+# Font family. Override with any installed system font.
+fontFamily=Google Sans Flex Freeze


### PR DESCRIPTION
Noticed while customizing the theme that `theme.conf` declares `primaryColor`, `fontFamily`, and `fontSize`, and the flake accepts all three as overrides — but none of them are actually read by any QML. Setting them does nothing.

This PR:
- Drops `primaryColor` and `fontSize`. They're not referenced anywhere in the QML, so they were silent no-ops.
- Wires `config.fontFamily` into `Main.qml` via two derived properties that fall back to the bundled FontLoaders when unset.
- Sets the default `fontFamily` to `Google Sans Flex Freeze` — the actual family name embedded in `assets/fonts/FlexRounded-*.ttf` (verified with `fc-query`). The previous default `FlexRounded` was a string Qt couldn't resolve, but it didn't matter since the value was never read.

Small breaking change for the flake API: passing `primaryColor` or `fontSize` to `.override { ... }` now raises a Nix eval error instead of being silently ignored. No rendered behavior changes either way.