### PR TITLE
fix(session): hide session pill when only one session is registered

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -520,6 +520,7 @@ Rectangle {
 
                 Rectangle {
                     id: sessionPill
+                    visible: typeof sessionModel !== "undefined" && sessionModel.count > 1
                     Layout.alignment: Qt.AlignHCenter
                     Layout.preferredWidth: 180
                     Layout.preferredHeight: 36


### PR DESCRIPTION
The session pill renders unconditionally, even when `sessionModel.count` is 1. The "▾" caret already hides in that case (`Main.qml:551`), but the pill itself doesn't — so it sits there showing a session you can't switch away from.

One-line fix: bind `sessionPill.visible` to `count > 1`. The defensive `typeof sessionModel !== "undefined"` half matches the existing style in the same block (the inner `Text { text: ... }` does the same check).